### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Net/SMTP.pm6
+++ b/lib/Net/SMTP.pm6
@@ -1,4 +1,4 @@
-class Net::SMTP;
+unit class Net::SMTP;
 
 use Net::SMTP::Raw;
 use Net::SMTP::Simple;

--- a/lib/Net/SMTP/Raw.pm6
+++ b/lib/Net/SMTP/Raw.pm6
@@ -1,4 +1,4 @@
-role Net::SMTP::Raw;
+unit role Net::SMTP::Raw;
 
 use MIME::Base64;
 use Digest;

--- a/lib/Net/SMTP/Simple.pm6
+++ b/lib/Net/SMTP/Simple.pm6
@@ -1,4 +1,4 @@
-role Net::SMTP::Simple;
+unit role Net::SMTP::Simple;
 
 use Email::Simple;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.