### PR TITLE
Changes to tests required after grapheme changes

### DIFF
--- a/lib/Net/SMTP.pm6
+++ b/lib/Net/SMTP.pm6
@@ -31,7 +31,7 @@ method new(:$server!, :$port = 25, :$raw, :$debug, :$hostname, :$socket = IO::So
         $self does Net::SMTP::Raw;
         $self.conn = $socket.defined ?? $socket !! $socket.new(:host($server), :$port);
         $self.conn = $self.conn but debug-connection if $debug;
-        $self.conn.input-line-separator = "\r\n";
+        $self.conn.nl-in = "\r\n";
     } else {
         $self does Net::SMTP::Simple;
         $self.hostname = $hostname // gethostname;

--- a/lib/Net/SMTP/Raw.pm6
+++ b/lib/Net/SMTP/Raw.pm6
@@ -35,7 +35,7 @@ method starttls() {
 }
 method switch-to-ssl() {
     $!conn = IO::Socket::SSL.new(:client-socket($.conn));
-    $!conn.input-line-separator = "\r\n";
+    $!conn.nl-in = "\r\n";
 }
 
 method mail-from($address) {

--- a/lib/Net/SMTP/Raw.pm6
+++ b/lib/Net/SMTP/Raw.pm6
@@ -35,7 +35,7 @@ method starttls() {
 }
 method switch-to-ssl() {
     $!conn = IO::Socket::SSL.new(:client-socket($.conn));
-    $!conn.nl-in = "\r\n";
+    $!conn.input-line-separator = "\r\n";
 }
 
 method mail-from($address) {

--- a/t/01-raw.t
+++ b/t/01-raw.t
@@ -32,7 +32,7 @@ class SMTPSocket {
         return @server-send.shift;
     }
     method print($string is copy) {
-        $string .= substr(0,*-2); # strip \r\n
+        $string.subst-mutate(/\r\n$/,'');
         die "Bad client-send" unless $string eq @server-get.shift;
     }
 }

--- a/t/01-raw.t
+++ b/t/01-raw.t
@@ -24,7 +24,7 @@ class SMTPSocket {
 
     has $.host;
     has $.port;
-    has $.input-line-separator is rw = "\n";
+    has $.nl-in is rw = "\n";
     method new(:$host, :$port) {
         self.bless(:$host, :$port);
     }
@@ -46,7 +46,7 @@ my $client = Net::SMTP.new(:server('foo.com'), :port(25), :raw, :socket(SMTPSock
 ok $client ~~ Net::SMTP, "Created raw class";
 ok $client.conn.host eq 'foo.com', "with right host";
 ok $client.conn.port eq '25', 'with right port';
-ok $client.conn.input-line-separator eq "\r\n", 'with right line sep';
+ok $client.conn.nl-in eq "\r\n", 'with right line sep';
 
 ok $client.get-response.substr(0,1) eq '2', 'Greeting';
 ok $client.helo('clientdomain.com').substr(0,1) eq '2', 'HELO';

--- a/t/02-simple.t
+++ b/t/02-simple.t
@@ -32,7 +32,7 @@ class SMTPSocket {
 
     has $.host;
     has $.port;
-    has $.input-line-separator is rw = "\n";
+    has $.nl-in is rw = "\n";
     method new(:$host, :$port) {
         self.bless(:$host, :$port);
     }

--- a/t/02-simple.t
+++ b/t/02-simple.t
@@ -40,7 +40,7 @@ class SMTPSocket {
         return @server-send.shift;
     }
     method print($string is copy) {
-        $string .= substr(0,*-2); # strip \r\n
+        $string.subst-mutate(/\r\n$/,'');
         die "Bad client-send: $string" unless $string eq @server-get.shift;
     }
     method close { }

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -35,7 +35,7 @@ class SMTPSocket {
         return @server-send.shift;
     }
     method print($string is copy) {
-        $string .= substr(0,*-2); # strip \r\n
+        $string.subst-mutate(/\r\n$/,'');
         die "Bad client-send: $string" unless $string eq @server-get.shift;
     }
     method close { }

--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -27,7 +27,7 @@ class SMTPSocket {
 
     has $.host;
     has $.port;
-    has $.input-line-separator is rw = "\n";
+    has $.nl-in is rw = "\n";
     method new(:$host, :$port) {
         self.bless(:$host, :$port);
     }


### PR DESCRIPTION
Hi,
the tests were failing because \r\n is no longer really two characters in most places, so I've altered the substr to a subst-mutate in the tests and they all pass again.

Thanks.